### PR TITLE
fix: apply remark for markdown to HTML and adjust layout

### DIFF
--- a/app/about/page.js
+++ b/app/about/page.js
@@ -12,20 +12,22 @@ export default function AboutPage({ searchParams }) {
     const content = {
         kr: {
             title: "지금은 공사중!",
-            description:
-                "지난 2년 동안 notion, velog, 지면에 기록한 내용들을 모아 정리하고 있습니다.",
-            role: "소프트웨어 엔지니어",
+            description1:
+                "지난 기간 notion, velog, 지면 등에 기록한 내용들을 모아 정리하고 있습니다. 아이디어를 구현하거나, 문제를 발견하고 해결하는 것에 관심이 있습니다. 주로 Java, Javascript를 활용합니다.",
+            description2: "해당 블로그는 next.js를 사용하여 제작되었습니다.",
+            role: "Software Engineer",
         },
         jp: {
             title: "工事中です！",
-            description:
-                "過去2年間のnotion、velog、紙面に記録した内容を集めて整理しています。",
-            role: "ソフトウェアエンジニア",
+            description1:
+                "これまでのnotion、velog、紙面などに記録した内容を集めて整理しています。アイデアを実現したり、問題を発見して解決することに興味があります。主にJavaとJavaScriptを活用しています。",
+            description2: "このブログはNext.jsを使って作成されました。",
+            role: "Software Engineer",
         },
     };
 
     return (
-        <div className="max-w-lg mx-auto my-10 bg-white rounded-lg shadow-md p-5">
+        <div className="max-w-xl mx-auto my-10 b p-5">
             <Image
                 className="rounded-full mx-auto"
                 src="https://avatars.githubusercontent.com/u/165984445?v=4"
@@ -40,26 +42,40 @@ export default function AboutPage({ searchParams }) {
             <div className="flex justify-center mt-5">
                 <a
                     href="https://github.com/june-76"
-                    className="text-blue-500 hover:text-blue-700 mx-3"
+                    className="text-grey-600 mx-3 hover-highlight"
+                    target="_blank"
+                    rel="noopener noreferrer"
                 >
                     GitHub
                 </a>
-                <a href="" className="text-blue-500 hover:text-blue-700 mx-3">
+                <a
+                    href=""
+                    className="text-grey-600 mx-3 hover-highlight"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                >
                     LinkedIn
                 </a>
                 <a
                     href="https://x.com/junefromjuly"
-                    className="text-blue-500 hover:text-blue-700 mx-3"
+                    className="text-grey-600 mx-3 hover-highlight"
+                    target="_blank"
+                    rel="noopener noreferrer"
                 >
                     Twitter
                 </a>
             </div>
-            <div className="mt-5">
+            <div className="mt-10">
                 <h3 className="text-xl font-semibold">
                     {content[language].title}
                 </h3>
-                <p className="text-gray-600 mt-2">
-                    {content[language].description}
+                <p className="text-gray-600">
+                    {content[language].description1}
+                </p>
+            </div>
+            <div className="mt-10">
+                <p className="text-gray-600">
+                    {content[language].description2}
                 </p>
             </div>
         </div>

--- a/app/categories/[slug]/page.js
+++ b/app/categories/[slug]/page.js
@@ -75,13 +75,9 @@ export default async function CategoryPage({ params, searchParams }) {
                                     <p className="block antialiased font-sans text-base leading-relaxed text-inherit mb-8 font-normal !text-gray-500">
                                         {post.description}
                                     </p>
-                                    <div className="flex items-center gap-4">
-                                        <div>
-                                            <p className="block antialiased font-sans text-base font-light leading-relaxed text-blue-gray-900 mb-0.5 !font-semibold">
-                                                {formatDate(post.date)}
-                                            </p>
-                                        </div>
-                                    </div>
+                                    <p className="block antialiased text-sm leading-normal text-gray-700 font-normal">
+                                        {formatDate(post.date)}
+                                    </p>
                                 </div>
                             </div>
                         ))

--- a/app/components/Header.js
+++ b/app/components/Header.js
@@ -26,6 +26,8 @@ function HeaderContent({ categories }) {
     const pathname = usePathname(); // 현재 경로 가져오기
     const language = searchParams.get("lang") || "kr";
 
+    console.log("Current pathname:", pathname); // Debugging line
+
     // 현재 활성화된 카테고리 확인 함수
     const isActiveCategory = (categorySlug) => {
         if (categorySlug === "home") {
@@ -44,13 +46,22 @@ function HeaderContent({ categories }) {
         window.location.href = newUrl; // URL을 직접 설정하여 페이지 이동
     };
 
+    // 특정 경로에서 언어 토글 컨테이너를 숨기기 위한 조건
+    const hideLanguageToggle = pathname.startsWith("/posts");
+
     return (
         <header>
             <div className="header-links">
                 <Link href="/" className="site-link">
                     junefromjuly
                 </Link>
-                <Link href="/about" className="about-link">
+                <Link
+                    href="/about"
+                    className={`about-link ${
+                        pathname === "/about" ? "highlight" : ""
+                    }`}
+                    style={pathname === "/about" ? { color: "#fade27" } : {}}
+                >
                     About
                 </Link>
             </div>
@@ -95,33 +106,35 @@ function HeaderContent({ categories }) {
                 </ul>
             </nav>
 
-            <div className="language-toggle-container">
-                <button
-                    className="language-switch-button"
-                    onClick={toggleLanguage}
-                    aria-label="Toggle Language"
-                >
-                    <span
-                        className={`switch-option kr ${
-                            language === "kr" ? "active" : ""
-                        }`}
+            {!hideLanguageToggle && (
+                <div className="language-toggle-container">
+                    <button
+                        className="language-switch-button"
+                        onClick={toggleLanguage}
+                        aria-label="Toggle Language"
                     >
-                        KR
-                    </span>
-                    <span
-                        className={`switch-option jp ${
-                            language === "jp" ? "active" : ""
-                        }`}
-                    >
-                        JP
-                    </span>
-                    <span
-                        className={`switch-slider ${
-                            language === "jp" ? "jp-active" : ""
-                        }`}
-                    ></span>
-                </button>
-            </div>
+                        <span
+                            className={`switch-option kr ${
+                                language === "kr" ? "active" : ""
+                            }`}
+                        >
+                            KR
+                        </span>
+                        <span
+                            className={`switch-option jp ${
+                                language === "jp" ? "active" : ""
+                            }`}
+                        >
+                            JP
+                        </span>
+                        <span
+                            className={`switch-slider ${
+                                language === "jp" ? "jp-active" : ""
+                            }`}
+                        ></span>
+                    </button>
+                </div>
+            )}
         </header>
     );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,8 +1,5 @@
 /* globals.css */
 
-/* Import Google Font */
-@import url("https://fonts.googleapis.com/css2?family=Orbit:wght@400;700&display=swap");
-
 /* Tailwind CSS Layers */
 @tailwind base;
 @tailwind components;

--- a/app/globals.css
+++ b/app/globals.css
@@ -54,6 +54,10 @@ header .about-link {
     margin-top: 4px;
 }
 
+header .about-link.highlight {
+    color: #fade27;
+}
+
 header .language-toggle {
     position: absolute;
     top: 10px;
@@ -221,4 +225,12 @@ ul {
 
 .switch-slider.jp-active {
     transform: translateX(28px);
+}
+
+.highlight {
+    color: #fade27;
+}
+
+.hover-highlight:hover {
+    color: #fade27;
 }

--- a/app/layout.js
+++ b/app/layout.js
@@ -3,6 +3,24 @@
 import "./globals.css";
 import Header from "./components/Header";
 import { Analytics } from "@vercel/analytics/react";
+import { Ubuntu } from "next/font/google";
+import { Noto_Sans_KR } from "next/font/google";
+import { Orbit } from "next/font/google";
+
+const ubuntu = Ubuntu({
+    weight: "400",
+    subsets: ["latin"],
+});
+
+const notoSansKR = Noto_Sans_KR({
+    weight: "200",
+    subsets: ["latin"],
+});
+
+const orbit = Orbit({
+    weight: "400",
+    subsets: ["latin"],
+});
 
 // 카테고리 하드코딩
 const loadCategories = () => {
@@ -39,9 +57,8 @@ export default function RootLayout({ children }) {
     const categories = loadCategories();
 
     return (
-        <html lang="ko">
-            <body>
-                {/* 헤더에 카테고리 데이터 전달 */}
+        <html>
+            <body className={`${orbit.className}`}>
                 <Header categories={categories} />
                 <main>{children}</main>
                 <footer

--- a/app/layout.js
+++ b/app/layout.js
@@ -41,10 +41,6 @@ const loadCategories = () => {
             name: "CS / Algorithm",
             slug: "cs-algorithm",
         },
-        {
-            name: "temp",
-            slug: "temp",
-        },
     ];
 };
 

--- a/app/page.js
+++ b/app/page.js
@@ -93,19 +93,19 @@ export default async function HomePage({ searchParams }) {
                                     </a>
                                 </div>
                                 <div className="p-6 px-2 sm:pr-6 sm:pl-4">
-                                    <p className="block antialiased font-sans text-sm font-light leading-normal text-inherit mb-4 !font-semibold">
+                                    <p className="block antialiased text-sm font-light leading-normal text-inherit mb-4 !font-semibold">
                                         {post.category}
                                     </p>
                                     <a
                                         href={`/posts/${post.id}?lang=${language}`}
-                                        className="block antialiased tracking-normal font-sans text-xl font-semibold leading-snug text-blue-gray-900 mb-2 normal-case transition-colors hover:text-gray-700"
+                                        className="block antialiased tracking-normal text-xl font-semibold leading-snug text-blue-gray-900 mb-2 normal-case transition-colors hover:text-gray-700"
                                     >
                                         {post.title}
                                     </a>
-                                    <p className="block antialiased font-sans text-base leading-relaxed text-inherit mb-8 font-normal !text-gray-500">
+                                    <p className="block antialiased text-base leading-relaxed text-inherit mb-8 font-normal !text-gray-500">
                                         {post.description}
                                     </p>
-                                    <p className="block antialiased font-sans text-sm leading-normal text-gray-700 font-normal">
+                                    <p className="block antialiased text-sm leading-normal text-gray-700 font-normal">
                                         {formatDate(post.date)}
                                     </p>
                                 </div>

--- a/app/page.js
+++ b/app/page.js
@@ -72,25 +72,14 @@ export default async function HomePage({ searchParams }) {
                                 className="relative flex-col bg-clip-border rounded-xl bg-white text-gray-700 shadow-none grid gap-2 item sm:grid-cols-2"
                             >
                                 <div className="relative bg-clip-border rounded-xl overflow-hidden bg-white text-gray-700 m-0 p-4">
-                                    <a
-                                        href={`/posts/${post.id}?lang=${language}`}
-                                    >
-                                        <div
-                                            className="relative w-full"
-                                            style={{
-                                                aspectRatio: "4/3",
-                                            }}
-                                        >
-                                            <img
-                                                src={
-                                                    post.thumbnail ||
-                                                    "https://placehold.co/600x400"
-                                                }
-                                                alt={`Thumbnail for ${post.title}`}
-                                                className="absolute inset-0 w-full h-full object-cover"
-                                            />
-                                        </div>
-                                    </a>
+                                    <img
+                                        src={
+                                            post.thumbnail ||
+                                            "https://placehold.co/600x400"
+                                        }
+                                        alt={`Thumbnail for ${post.title}`}
+                                        className="object-cover w-full h-full"
+                                    />
                                 </div>
                                 <div className="p-6 px-2 sm:pr-6 sm:pl-4">
                                     <p className="block antialiased text-sm font-light leading-normal text-inherit mb-4 !font-semibold">

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
         "remark": "^15.0.1",
         "remark-breaks": "^4.0.0",
         "remark-html": "^16.0.1",
-        "remark-prism": "^1.3.6"
+        "remark-prism": "^1.3.6",
+        "unified": "^11.0.5"
       },
       "devDependencies": {
         "@types/node": "^20",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "remark": "^15.0.1",
     "remark-breaks": "^4.0.0",
     "remark-html": "^16.0.1",
-    "remark-prism": "^1.3.6"
+    "remark-prism": "^1.3.6",
+    "unified": "^11.0.5"
   },
   "devDependencies": {
     "@types/node": "^20",


### PR DESCRIPTION
## 주요 변경 사항
1.  개별 포스트 페이지의 마크다운 파일 스타일링
    - remark
2. 한국어/일본어 전환 토글은 글 목록에서만 작동하도록 변경
    - 포스트 상세 페이지에서는 어떻게 작동시킬 것인 지 고려가 필요함.
    - parentId 컬럼을 생성하여 jp 포스트가 kr 포스트의 postId를 참조하는 방향으로 진행중
3. 스타일 변경
    - about  페이지 스타일 조정
    - 폰트 적용

## 남은 작업
- [ ] 태그 기능 추가